### PR TITLE
Use fsHost, fsNamespace and fsDebug from config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nibo-ai/ngx-fullstory",
-  "version": "2.0.1",
+  "name": "ngx-fullstory",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nibo-ai/ngx-fullstory",
-  "version": "2.0.2",
+  "name": "ngx-fullstory",
+  "version": "2.0.3",
   "scripts": {
     "ng": "ng",
     "build": "ng build",

--- a/projects/ngx-fullstory/package.json
+++ b/projects/ngx-fullstory/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@nibo-ai/ngx-fullstory",
-  "version": "2.0.2",
+  "name": "ngx-fullstory",
+  "version": "2.0.3",
   "peerDependencies": {
     "@angular/common": ">=6.1.0",
     "@angular/core": ">=6.1.0"

--- a/projects/ngx-fullstory/src/lib/fullstory/fullstory.ts
+++ b/projects/ngx-fullstory/src/lib/fullstory/fullstory.ts
@@ -61,7 +61,7 @@ export class Fullstory {
     const win = (window as any);
 
     win['_fs_debug'] = false;
-    win['_fs_host'] = 'fullstory.com';
+    win['_fs_host'] = config.fsHost || 'fullstory.com';
     win['_fs_org'] = config.fsOrg;
     win['_fs_namespace'] = 'FS';
 

--- a/projects/ngx-fullstory/src/lib/fullstory/fullstory.ts
+++ b/projects/ngx-fullstory/src/lib/fullstory/fullstory.ts
@@ -60,10 +60,10 @@ export class Fullstory {
     const args = arguments;
     const win = (window as any);
 
-    win['_fs_debug'] = false;
+    win['_fs_debug'] = (typeof config.fsDebug !== "undefined" ? config.fsDebug : false);
     win['_fs_host'] = config.fsHost || 'fullstory.com';
     win['_fs_org'] = config.fsOrg;
-    win['_fs_namespace'] = 'FS';
+    win['_fs_namespace'] = config.fsNameSpace || 'FS';
 
     const load = (m: any, n: any, e: any, t: any, l: any) => {
         if (e in m) {

--- a/projects/ngx-fullstory/src/lib/types/fullstory-config.ts
+++ b/projects/ngx-fullstory/src/lib/types/fullstory-config.ts
@@ -1,7 +1,0 @@
-export interface FullstoryConfig {
-
-    /**
-     * Your fullstory Org ID
-     */
-    fsOrg: string
-}


### PR DESCRIPTION
Currently fsHost from configuration is ignored. The same for fsDebug and fsNamespace.
Also types/fullstory-config is not used, the one in shared is used.
Could you also please publish to npm the new version after merging this PR? Thanks!